### PR TITLE
Change image name

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+## finalduty/archlinux
+FROM scratch
+MAINTAINER FinalDuty <root@finalduty.me>
+
+ADD archlinux-2017.09.20.tar.xz /
+
+CMD /bin/bash

--- a/README.md
+++ b/README.md
@@ -1,0 +1,58 @@
+![](https://img.shields.io/docker/stars/finalduty/archlinux.png) 
+![](https://img.shields.io/docker/pulls/finalduty/archlinux.png) 
+
+### Releases and Tags
+
+* ````latest```` - Updated on every push to Master [Dockerfile](https://github.com/finalduty/docker-archlinux/blob/master/Dockerfile)
+* ````daily```` - Updated once every day [Dockerfile](https://github.com/finalduty/docker-archlinux/blob/daily/Dockerfile)
+* ````weekly```` - Updated every Sunday night [Dockerfile](https://github.com/finalduty/docker-archlinux/blob/weekly/Dockerfile)
+* ````monthly```` - Updated on the first day of every month [Dockerfile](https://github.com/finalduty/docker-archlinux/blob/monthly/Dockerfile)
+
+Tagged images are built from the same source repo. The only difference is when the Git Tags on the repo are updated. For example, if you pull the monthly and daily images on the 1st of the month, the contents of each image will be the same. The only difference will be the Image ID as Dockerhub builds the two as seperate images.
+
+### Arch Linux
+![](https://sources.archlinux.org/other/artwork/archlinux-logo-dark-90dpi.png)
+
+Arch Linux is an independently developed, i686/x86-64 general-purpose GNU/Linux distribution that strives to provide the latest stable versions of most software by following a rolling-release model, allowing for a one-time install with continuous upgrades. The default installation is a minimal base system, configured by the user to only add what is required for his purposes. 
+
+> [wiki.archlinux.org](https://wiki.archlinux.org/index.php/Arch_Linux)
+
+### Image Build Process
+This image is built from scratch each day, using a modified version of [tmc's](https://github.com/tmc) [mkimage-arch.sh](https://github.com/dotcloud/docker/blob/master/contrib/mkimage-arch.sh) script. The script is triggered by anacron and runs completely unattended. As such, you can expect a fresh, up to date base image, every day of the week.
+
+
+### Usage
+Try out the container via CLI:
+```
+docker pull finalduty/archlinux:daily
+docker run --rm -it finalduty/archlinux:daily
+```
+
+Build your own image from a Dockerfile via CLI:
+```
+cat << EOF > Dockerfile
+FROM finalduty/archlinux:weekly
+MAINTAINER foo <foo@bar.com>
+RUN pacman -Syu vim --noconfirm; pacman -Scc --noconfirm
+EOF
+docker build -t local/archlinux -f Dockerfile .
+```
+
+### Caveats
+##### Localisations and Man-Pages
+To keep the size of the image down, a number of files are deleted during the build process, including man-pages and localisations. To see which files have been deleted, you can run ````pacman -Qkq````. If you need to replace one of these files, reinstall the applicable package then removing any extraneous files. Make sure to do this in one layer to save on wasted space. For instance if you wanted to add a certain localisation (en_GB in this example) you could use a Dockerfile such as the one below. It's a long one, but it'll help keep your image size down:
+
+```
+FROM finalduty/archlinux:daily
+MAINTAINER foo <foo@bar.com>
+RUN pacman -Q | awk '{print $1}' | pacman -Syu --noconfirm -; pacman -Scc --noconfirm; rm -r /usr/share/man/*; ls -d /usr/share/locale/* | egrep -v "alias|en_GB" | xargs rm -rf
+```
+
+##### systemd
+I haven't tested if this works or what is required to get it to work. It is possible to take the ExecStart command out of a package's unit file and add that as a CMD layer to your own Dockerfile. This example will start xinetd and a bash shell so you can still attach to the container:
+
+```
+FROM finalduty/archlinux:monthly
+MAINTAINER foo <foo@bar.com>
+CMD /usr/bin/xinetd -dontfork; /bin/bash
+```

--- a/mkdocker-archlinux.sh
+++ b/mkdocker-archlinux.sh
@@ -1,0 +1,122 @@
+#!/bin/bash 
+set -e 
+
+export LANG="C.UTF-8"
+umask=022
+
+## Variables
+GITDIR='/root/archlinux/'
+DATE=`date +%Y.%m.%d`
+ROOTFS=`mktemp -d ${TMPDIR:-/var/tmp}/rootfs-archlinux-XXXXXXXXXX`
+
+## Ignored packages to reduce image size
+PKGIGNORE=(
+    cryptsetup
+    device-mapper
+    dhcpcd
+    gcc-go
+    iproute2
+    jfsutils
+    linux
+    lvm2
+    man-db
+    man-pages
+    mdadm
+    nano
+    netctl
+    openresolv
+    pciutils
+    pcmciautils
+    reiserfsprogs
+    s-nail
+    systemd-sysvcompat
+    vi
+    xfsprogs
+)
+IFS=','
+PKGIGNORE="${PKGIGNORE[*]}"
+unset IFS
+
+pacman -Syu --noconfirm
+
+expect <<EOF
+	set send_slow {1 .1}
+    proc send {ignore arg} {
+		sleep .1
+	exp_send -s -- \$arg
+	}
+	set timeout 3600
+
+	spawn pacstrap -c -d -G -i $ROOTFS base haveged $PACMAN_EXTRA_PKGS --ignore $PKGIGNORE
+	expect {
+		-exact "anyway? \[Y/n\] " { send -- "n\r"; exp_continue }
+		-exact "(default=all): " { send -- "\r"; exp_continue }
+		-exact "installation? \[Y/n\]" { send -- "y\r"; exp_continue }
+	}
+EOF
+
+arch-chroot $ROOTFS /bin/sh -c 'rm -r /usr/share/man/*'
+arch-chroot $ROOTFS /bin/sh -c 'ls -d /usr/share/locale/* | egrep -v "en_U|alias" | xargs rm -rf'
+arch-chroot $ROOTFS /bin/sh -c "haveged -w 1024; pacman-key --init; pkill haveged; pacman -Rsu --noconfirm haveged; pacman-key --populate archlinux; pkill gpg-agent"
+arch-chroot $ROOTFS /bin/sh -c "ln -s /usr/share/zoneinfo/UTC /etc/localtime"
+echo 'en_US.UTF-8 UTF-8' > $ROOTFS/etc/locale.gen
+arch-chroot $ROOTFS locale-gen
+arch-chroot $ROOTFS /bin/sh -c 'rm -rf /usr/lib/firmware/*
+
+# udev doesn't work in containers, rebuild /dev
+DEV=$ROOTFS/dev
+rm -rf $DEV
+mkdir -p $DEV
+mknod -m 666 $DEV/null c 1 3
+mknod -m 666 $DEV/zero c 1 5
+mknod -m 666 $DEV/random c 1 8
+mknod -m 666 $DEV/urandom c 1 9
+mkdir -m 755 $DEV/pts
+mkdir -m 1777 $DEV/shm
+mknod -m 666 $DEV/tty c 5 0
+mknod -m 600 $DEV/console c 5 1
+mknod -m 666 $DEV/tty0 c 4 0
+mknod -m 666 $DEV/full c 1 7
+mknod -m 600 $DEV/initctl p
+mknod -m 666 $DEV/ptmx c 5 2
+ln -sf /proc/self/fd $DEV/fd
+
+
+## Compress and add to git repo
+cd $GITDIR
+git fetch --depth=1 --tags
+git rm "$GITDIR/*.xz"
+XZ_OPTS=-2 tar --checkpoint=2500 --warning=no-file-ignored --numeric-owner -C $ROOTFS -cJf "archlinux-$DATE.tar.xz" .
+chmod -v 644 "archlinux-$DATE.tar.xz"
+sed -i "s|^ADD archlinux-.*$|ADD archlinux-$DATE.tar.xz /|" Dockerfile
+git add "archlinux-$DATE.tar.xz" Dockerfile
+
+## Update Tags - Only run at certain hours or on certain dates
+if [ `date +%H` -ne 3 ]; then
+    git commit -m "Auto Update - $DATE"
+    git tag -d daily && git push origin :daily
+    git tag -a daily -m "Daily Update - $DATE"
+    if [ `date +%u` -eq 1 ]; then
+        git tag -d weekly && git push origin :weekly
+        git tag -a weekly -m "Weekly Update - $DATE"
+    fi
+    if [ `date +%d` -eq 1 ]; then
+        git tag -d monthly && git push origin :monthly
+        git tag -a monthly -m "Monthly Update - $DATE"
+    fi
+else
+    git commit  
+fi
+
+## Push new files and tags to git (obviously :p)
+git push --follow-tags
+
+## Clean out build location
+rm -rf $ROOTFS
+
+## Clean out local git repo to keep disk use down
+find $GITDIR -mindepth -delete
+git clone --depth=1 git@github.com:finalduty/docker-archlinux $GITDIR
+git fetch --tags --depth=1
+chown andy. -R /root/archlinux/
+


### PR DESCRIPTION
Seems old image name was called `finalduty/docker`, but seems now it `finalduty/archlinux`
And `docker pull finalduty/docker:daily` cause
`Error response from daemon: repository finalduty/docker not found: does not exist or no pull access`